### PR TITLE
Thread pool and production queue optimizations + benchmark

### DIFF
--- a/.assertions/dependency_manager/install.sh
+++ b/.assertions/dependency_manager/install.sh
@@ -3,3 +3,4 @@ apt-package/install.sh g++
 apt-package/install.sh cmake
 apt-package/install.sh make
 git/install.sh https://github.com/rockerbacon/assertions-test.git v2.0.4 true "src/objs" "src/objs" ""
+git/install.sh https://github.com/rockerbacon/cpp-benchmark.git v1.0.5 false "src/objs" "src/objs" ""

--- a/src/main/benchmakrs/thread_pool/void_signature.cpp
+++ b/src/main/benchmakrs/thread_pool/void_signature.cpp
@@ -5,7 +5,7 @@
 
 #include <thread_pool.h>
 
-#define MAX_THREADS 4
+#define MAX_THREADS 16
 #define TASKS_PER_RUN 500'000
 #define RUNS 50
 

--- a/src/main/benchmakrs/thread_pool/void_signature.cpp
+++ b/src/main/benchmakrs/thread_pool/void_signature.cpp
@@ -5,9 +5,9 @@
 
 #include <thread_pool.h>
 
-#define MAX_THREADS 32
+#define MAX_THREADS 8
 #define TASKS_PER_RUN 100'000
-#define RUNS 10
+#define RUNS 50
 
 #define SETUP_BENCHMARK()\
 	TerminalObserver terminal_observer;\

--- a/src/main/benchmakrs/thread_pool/void_signature.cpp
+++ b/src/main/benchmakrs/thread_pool/void_signature.cpp
@@ -1,0 +1,69 @@
+#include <stopwatch/stopwatch.h>
+#include <cpp-benchmark/benchmark.h>
+#include <thread>
+#include <vector>
+
+#include <thread_pool.h>
+
+#define MAX_THREADS 32
+#define TASKS_PER_RUN 100'000
+#define RUNS 10
+
+#define SETUP_BENCHMARK()\
+	TerminalObserver terminal_observer;\
+	chrono::high_resolution_clock::duration production_time,\
+											consumption_time;\
+	unsigned run;\
+	float progress;\
+\
+	register_observers(terminal_observer);\
+\
+	observe(progress, percentage_complete);\
+\
+	observe_average(production_time, average_production_time);\
+	observe_minimum(production_time, fastest_production_time);\
+	observe_maximum(production_time, slowest_production_time);\
+\
+	observe_average(consumption_time, average_consumption_time);\
+	observe_minimum(consumption_time, fastest_consumpion_time);\
+	observe_maximum(consumption_time, slowest_consumption_time);\
+
+
+using namespace benchmark;
+using namespace std;
+
+int main() {
+	for (unsigned threads = 2; threads <= MAX_THREADS; threads *= 2) {
+		SETUP_BENCHMARK();
+
+		run = 0;
+		parallel_tools::thread_pool pool(threads);
+		string benchmark_description = "parallel_tools::thread_pool with void() method and "s + to_string(threads) + " threads";
+		benchmark(benchmark_description, RUNS) {
+			vector<future<void>> tasks_futures; tasks_futures.reserve(TASKS_PER_RUN);
+			vector<chrono::high_resolution_clock::duration> tasks_consumption_time(TASKS_PER_RUN);
+			vector<stopwatch> stopwatches(TASKS_PER_RUN);
+			stopwatch stopwatch;
+
+			for (unsigned i = 0; i < TASKS_PER_RUN; i++) {
+				auto task = [
+					&consumption_time = tasks_consumption_time[i],
+					&stopwatch = stopwatches[i]
+				] {
+					consumption_time = stopwatch.lap_time();
+				};
+
+				tasks_futures.emplace_back(pool.exec(task));
+			}
+			production_time = stopwatch.lap_time();
+
+			for (auto& future : tasks_futures) {
+				future.wait();
+			}
+			consumption_time = *max_element(tasks_consumption_time.begin(), tasks_consumption_time.end());
+
+			run++;
+			progress = (float)run/RUNS*100.0f;
+		}
+	}
+}

--- a/src/main/benchmakrs/thread_pool/void_signature.cpp
+++ b/src/main/benchmakrs/thread_pool/void_signature.cpp
@@ -5,8 +5,8 @@
 
 #include <thread_pool.h>
 
-#define MAX_THREADS 8
-#define TASKS_PER_RUN 100'000
+#define MAX_THREADS 4
+#define TASKS_PER_RUN 500'000
 #define RUNS 50
 
 #define SETUP_BENCHMARK()\

--- a/src/objs/production_queue.h
+++ b/src/objs/production_queue.h
@@ -9,38 +9,59 @@ namespace parallel_tools {
 	template<typename resource_type>
 	class production_queue {
 		private:
-			std::queue<resource_type> queue;
-			std::mutex queue_mutex;
+			std::queue<resource_type> producers_queue;
+			std::queue<resource_type> consumers_queue;
+			std::mutex producers_mutex;
+			std::mutex consumers_mutex;
 			std::condition_variable consumer_notifier;
-			volatile size_t resources_count;
+			std::atomic<size_t> available_consumer_resources;
+
+			void swap_queues_if_needed() {
+				bool swaped_queues = false;
+				if (available_consumer_resources == 0) {
+					std::scoped_lock lock(consumers_mutex, producers_mutex);
+					if (available_consumer_resources == 0 && !producers_queue.empty()) {
+						std::swap(producers_queue, consumers_queue);
+						available_consumer_resources = consumers_queue.size();
+						swaped_queues = true;
+					}
+				}
+				if (swaped_queues) {
+					consumer_notifier.notify_all();
+				}
+			}
 		public:
 			production_queue() :
-				resources_count(0)
+				available_consumer_resources(0)
 			{}
 
 			template<typename... args_types>
 			void produce(args_types... constructor_args) {
 				resource_type resource(std::forward<args_types...>(constructor_args...));
 				{
-					std::lock_guard lock(queue_mutex);
-					queue.emplace(std::move(resource));
-					resources_count++;
+					std::lock_guard lock(producers_mutex);
+					producers_queue.emplace(std::move(resource));
 				}
-				consumer_notifier.notify_one();
+				swap_queues_if_needed();
 			}
 
 			resource_type consume () {
-				std::unique_lock lock(queue_mutex);
-				consumer_notifier.wait(lock, [&] { return resources_count > 0; });
+				resource_type resource;
+				{
+					std::unique_lock lock(consumers_mutex);
+					consumer_notifier.wait(lock, [&] { return available_consumer_resources > 0; });
 
-				resource_type resource{std::move(queue.front())};
-				queue.pop();
-				resources_count--;
+					resource = std::move(consumers_queue.front());
+					consumers_queue.pop();
+					available_consumer_resources--;
+				}
+				swap_queues_if_needed();
 				return resource;
 			}
 
-			size_t available_resources() const {
-				return resources_count;
+			size_t available_resources() {
+				std::lock_guard lock(producers_mutex);
+				return available_consumer_resources+producers_queue.size();
 			}
 	};
 }

--- a/src/objs/production_queue.h
+++ b/src/objs/production_queue.h
@@ -36,7 +36,7 @@ namespace parallel_tools {
 				resource_type resource{std::move(queue.front())};
 				queue.pop();
 				resources_count--;
-				return std::move(resource);
+				return resource;
 			}
 
 			size_t available_resources() const {

--- a/src/objs/production_queue.h
+++ b/src/objs/production_queue.h
@@ -5,8 +5,6 @@
 #include <atomic>
 #include <queue>
 
-#include <iostream>
-
 namespace parallel_tools {
 	template<typename resource_type>
 	class production_queue {
@@ -22,9 +20,10 @@ namespace parallel_tools {
 
 			template<typename... args_types>
 			void produce(args_types... constructor_args) {
+				resource_type resource(std::forward<args_types...>(constructor_args...));
 				{
 					std::lock_guard lock(queue_mutex);
-					queue.emplace(std::forward<args_types...>(constructor_args...));
+					queue.emplace(std::move(resource));
 					resources_count++;
 				}
 				consumer_notifier.notify_one();

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -27,7 +27,7 @@ void thread_pool::terminate() {
 	running = false;
 	long long tasks_for_wakeup = (long long)threads.size() - (long long)task_queue.available_resources();
 	for (decltype(tasks_for_wakeup) i = 0; i < tasks_for_wakeup; i++) {
-		exec([]{ });
+		exec([]{});
 	}
 
 	for (auto& thread : threads) {
@@ -37,14 +37,5 @@ void thread_pool::terminate() {
 
 bool thread_pool::is_running() const {
 	return running;
-}
-
-future<void> thread_pool::exec(const std::function<void()>& task) {
-	packaged_task<void()> packaged_task(task);
-	auto future = packaged_task.get_future();
-
-	task_queue.produce(move(packaged_task));
-
-	return future;
 }
 

--- a/src/objs/thread_pool.h
+++ b/src/objs/thread_pool.h
@@ -38,6 +38,19 @@ namespace parallel_tools {
 
 				return future;
 			}
+
+			template<
+				typename function_type,
+				typename return_type = typename std::result_of<function_type()>::type
+			>
+			std::future<return_type> exec(const function_type& task) {
+				std::packaged_task<return_type()> packaged_task(task);
+				auto future = packaged_task.get_future();
+
+				task_queue.produce(std::move(packaged_task));
+
+				return future;
+			}
 	};
 
 }

--- a/tests/production_queue/multi_threaded.cpp
+++ b/tests/production_queue/multi_threaded.cpp
@@ -76,7 +76,7 @@ begin_tests {
 		const int consumers_count = 2;
 		const int producers_count = 2;
 
-		test_case("all resources should be consumed and none should be consumed more than once in less than 300ms") {
+		test_case("all resources should be consumed only once in less than 150ms") {
 			vector<atomic<unsigned>> consumption_counts(resources_count);
 			vector<thread> consumers;
 			vector<thread> producers;
@@ -125,7 +125,7 @@ begin_tests {
 			assert(stopwatch.lap_time(), <=, 300ms);
 		};
 
-		test_case("production should take no more than 150ms") {
+		test_case("production should take no more than 75ms") {
 			vector<thread> producers;
 			parallel_tools::production_queue<int> queue;
 
@@ -145,7 +145,7 @@ begin_tests {
 			assert(stopwatch.lap_time(), <=, 150ms);
 		};
 
-		test_case("consumption should take no more than 150ms") {
+		test_case("consumption should take no more than 75ms") {
 			vector<thread> consumers;
 			vector<thread> producers;
 			parallel_tools::production_queue<int> queue;

--- a/tests/thread_pool.cpp
+++ b/tests/thread_pool.cpp
@@ -280,7 +280,7 @@ begin_tests {
 
 	test_suite("when stressing a thread pool of 2 threads with 100,000 empty signature tasks") {
 		const int tasks_to_execute = 100'000;
-		test_case("pool should be able to execute all tasks in less than 150ms") {
+		test_case("pool should be able to execute all tasks in less than 75ms") {
 			thread_pool pool(2);
 			vector<future<void>> futures;
 			futures.reserve(tasks_to_execute);
@@ -300,7 +300,7 @@ begin_tests {
 
 	test_suite("when stressing a thread pool of 2 threads with 100,000 tasks with args but no return") {
 		const int tasks_to_execute = 100'000;
-		test_case("pool should be able to execute all tasks in less than 150ms") {
+		test_case("pool should be able to execute all tasks in less than 75ms") {
 			thread_pool pool(2);
 			vector<future<void>> futures;
 			futures.reserve(tasks_to_execute);
@@ -325,7 +325,7 @@ begin_tests {
 
 	test_suite("when stressing a thread pool of 2 threads with 100,000 tasks with args and return") {
 		const int tasks_to_execute = 100'000;
-		test_case("pool should be able to execute all tasks in less than 150ms") {
+		test_case("pool should be able to execute all tasks in less than 75ms") {
 			thread_pool pool(2);
 			vector<future<int>> futures;
 			futures.reserve(tasks_to_execute);

--- a/tests/thread_pool.cpp
+++ b/tests/thread_pool.cpp
@@ -12,22 +12,16 @@ begin_tests {
 			int processed_value1 = 0;
 			int processed_value2 = 0;
 
-				cerr << ("queueing first\n");
 			auto future = pool.exec([&]() {
 				processed_value1 = 10;
-				cerr << ("first finished\n");
 			});
 
 
-				cerr << ("queueing second\n");
 			future = pool.exec([&]() {
 				processed_value2 = 15;
-				cerr << ("second finished\n");
 			});
 
-				cerr << ("waiting\n");
 			future.wait();
-				cerr << ("finished\n");
 
 			assert(processed_value1, ==, 10);
 			assert(processed_value2, ==, 15);


### PR DESCRIPTION
The production queue suffered heavily from excessive locking when enough consumers and producers accessed it. To solve this issue a new strategy was employed to allow for a single consumption and a single production to happen at the same time instead of requiring atomicity.

Two queues are used: one exclusively for production and one exclusively for consumption, whenever the consumption queue empties, the consumption and production queues are swapped.

This method presented up to 10x more performance during the benchmarks.

The method still needs to be improved. With a large enough number of threads the swap procedure may generate relatively long waits and consumption time is a lot slower than production time which can lead to queue growth and memory related issues.
