### PR TITLE
Optimized production queue communication and added modular flush policy

### DIFF
--- a/src/main/benchmakrs/thread_pool/void_signature.cpp
+++ b/src/main/benchmakrs/thread_pool/void_signature.cpp
@@ -5,6 +5,7 @@
 
 #include <thread_pool.h>
 
+#define MIN_THREADS 16
 #define MAX_THREADS 16
 #define TASKS_PER_RUN 500'000
 #define RUNS 50
@@ -33,7 +34,7 @@ using namespace benchmark;
 using namespace std;
 
 int main() {
-	for (unsigned threads = 2; threads <= MAX_THREADS; threads *= 2) {
+	for (unsigned threads = MIN_THREADS; threads <= MAX_THREADS; threads *= 2) {
 		SETUP_BENCHMARK();
 
 		run = 0;

--- a/src/main/benchmakrs/thread_pool/void_signature.cpp
+++ b/src/main/benchmakrs/thread_pool/void_signature.cpp
@@ -5,8 +5,8 @@
 
 #include <thread_pool.h>
 
-#define MIN_THREADS 16
-#define MAX_THREADS 16
+#define MIN_THREADS 2
+#define MAX_THREADS 64
 #define TASKS_PER_RUN 500'000
 #define RUNS 50
 

--- a/src/main/benchmakrs/thread_pool/void_signature.cpp
+++ b/src/main/benchmakrs/thread_pool/void_signature.cpp
@@ -5,7 +5,7 @@
 
 #include <thread_pool.h>
 
-#define MIN_THREADS 16
+#define MIN_THREADS 4
 #define MAX_THREADS 64
 #define TASKS_PER_RUN 500'000
 #define RUNS 50
@@ -70,6 +70,7 @@ int main() {
 				tasks_futures.emplace_back(std::move(future));
 			}
 
+			pool.finish();
 			for (auto& future : tasks_futures) {
 				future.wait();
 			}

--- a/src/main/benchmarks/thread_pool/void_signature.cpp
+++ b/src/main/benchmarks/thread_pool/void_signature.cpp
@@ -70,6 +70,7 @@ int main() {
 				tasks_futures.emplace_back(std::move(future));
 			}
 
+			pool.finish();
 			for (auto& future : tasks_futures) {
 				future.wait();
 			}

--- a/src/main/benchmarks/thread_pool/void_signature.cpp
+++ b/src/main/benchmarks/thread_pool/void_signature.cpp
@@ -5,7 +5,7 @@
 
 #include <thread_pool.h>
 
-#define MIN_THREADS 4
+#define MIN_THREADS 2
 #define MAX_THREADS 64
 #define TASKS_PER_RUN 500'000
 #define RUNS 50
@@ -70,7 +70,6 @@ int main() {
 				tasks_futures.emplace_back(std::move(future));
 			}
 
-			pool.finish();
 			for (auto& future : tasks_futures) {
 				future.wait();
 			}

--- a/src/main/benchmarks/thread_pool/void_signature.cpp
+++ b/src/main/benchmarks/thread_pool/void_signature.cpp
@@ -70,7 +70,6 @@ int main() {
 				tasks_futures.emplace_back(std::move(future));
 			}
 
-			pool.finish();
 			for (auto& future : tasks_futures) {
 				future.wait();
 			}

--- a/src/objs/production_queue.h
+++ b/src/objs/production_queue.h
@@ -61,9 +61,6 @@ namespace parallel_tools {
 			}
 
 			resource_type consume () {
-				if (available_resources == 0 && unpublished_resources > 0) {
-					flush_production();
-				}
 				resource_type resource;
 				{
 					std::unique_lock lock(consumers_mutex);
@@ -72,6 +69,9 @@ namespace parallel_tools {
 					resource = std::move(consumers_queue.front());
 					consumers_queue.pop();
 					available_resources--;
+				}
+				if (available_resources == 0 && unpublished_resources > 0) {
+					flush_production();
 				}
 				return resource;
 			}

--- a/src/objs/production_queue.h
+++ b/src/objs/production_queue.h
@@ -5,6 +5,8 @@
 #include <atomic>
 #include <queue>
 
+#include <iostream>
+
 namespace parallel_tools {
 	template<typename resource_type>
 	class production_queue {
@@ -14,41 +16,36 @@ namespace parallel_tools {
 			std::mutex producers_mutex;
 			std::mutex consumers_mutex;
 			std::condition_variable consumer_notifier;
-			std::atomic<size_t> available_consumer_resources;
+			std::atomic<size_t> available_resources;
 			std::atomic<size_t> unpublished_resources;
 			std::atomic<size_t> waiting_consumers;
 			const size_t maximum_task_delay;
-			const size_t maximum_waiting_consumers;
 			std::atomic<bool> swap_in_progress;
 
-			void swap_queues() {
-				if (!swap_in_progress) {
-					bool swaped_queues = false;
-					swap_in_progress = true;
-					{
-						std::scoped_lock lock(consumers_mutex, producers_mutex);
-						if (available_consumer_resources == 0 && unpublished_resources > 0) {
-							std::swap(producers_queue, consumers_queue);
-							available_consumer_resources = consumers_queue.size();
-							unpublished_resources = 0;
-							swaped_queues = true;
-						}
-					}
-					if (swaped_queues) {
-						consumer_notifier.notify_all();
-					}
-					swap_in_progress = false;
-				}
-			}
 		public:
-			production_queue(size_t maximum_task_delay = 1, size_t maximum_waiting_consumers = 1) :
-				available_consumer_resources(0),
+			production_queue(size_t maximum_task_delay = 1) :
+				available_resources(0),
 				unpublished_resources(0),
 				waiting_consumers(0),
 				maximum_task_delay(maximum_task_delay),
-				maximum_waiting_consumers(maximum_waiting_consumers),
 				swap_in_progress(false)
 			{}
+
+			void flush_production() {
+				if (!swap_in_progress) {
+					swap_in_progress = true;
+					{
+						std::scoped_lock lock(consumers_mutex, producers_mutex);
+						if (unpublished_resources > 0) {
+							std::swap(producers_queue, consumers_queue);
+							available_resources = consumers_queue.size();
+							unpublished_resources = producers_queue.size();
+						}
+					}
+					swap_in_progress = false;
+					consumer_notifier.notify_all();
+				}
+			}
 
 			template<typename... args_types>
 			void produce(args_types... constructor_args) {
@@ -58,30 +55,35 @@ namespace parallel_tools {
 					producers_queue.emplace(std::move(resource));
 					unpublished_resources++;
 				}
-				if (
-					available_consumer_resources == 0
-				&&	(unpublished_resources >= maximum_task_delay || waiting_consumers >= maximum_waiting_consumers)
-				) {
-					swap_queues();
+				if (available_resources == 0 && unpublished_resources >= maximum_task_delay) {
+					flush_production();
 				}
 			}
 
 			resource_type consume () {
-				if (available_consumer_resources == 0 && unpublished_resources > 0) {
-					swap_queues();
+				if (available_resources == 0 && unpublished_resources > 0) {
+					flush_production();
 				}
 				resource_type resource;
 				{
 					std::unique_lock lock(consumers_mutex);
 					waiting_consumers++;
-					consumer_notifier.wait(lock, [&] { return available_consumer_resources > 0; });
+					consumer_notifier.wait(lock, [&] { return available_resources > 0; });
 					waiting_consumers--;
 
 					resource = std::move(consumers_queue.front());
 					consumers_queue.pop();
-					available_consumer_resources--;
+					available_resources--;
 				}
 				return resource;
+			}
+
+			size_t get_available_resources() {
+				return available_resources;
+			}
+
+			size_t get_unpublished_resources() {
+				return unpublished_resources;
 			}
 	};
 }

--- a/src/objs/production_queue.h
+++ b/src/objs/production_queue.h
@@ -161,7 +161,5 @@ namespace parallel_tools {
 				return unpublished_resources;
 			}
 	};
-
-
 }
 

--- a/src/objs/production_queue.h
+++ b/src/objs/production_queue.h
@@ -8,6 +8,8 @@
 
 namespace parallel_tools {
 	namespace flush_policy {
+		constexpr auto never = [] { return false; };
+		constexpr auto always = [] { return true; };
 		struct batches_of { size_t batch_size; };
 		struct maximum_waiting_consumers { size_t number_of_consumers; };
 	}
@@ -26,50 +28,95 @@ namespace parallel_tools {
 			std::atomic<bool> swap_in_progress;
 			std::function<bool()> flush_policy;
 
-		public:
-			production_queue() :
-				available_resources(0),
-				unpublished_resources(0),
-				waiting_consumers(0),
-				swap_in_progress(false),
-				flush_policy([] { return true; })
-			{}
-
-			production_queue(const flush_policy::batches_of& batches) :
-				production_queue()
-			{
-				flush_policy = [this, batches] {
-					return unpublished_resources >= batches.batch_size;
-				};
-			}
-
-			production_queue(const flush_policy::maximum_waiting_consumers& maximum_consumers) :
-				production_queue()
-			{
-				flush_policy = [this, maximum_consumers] {
-					return waiting_consumers >= maximum_consumers.number_of_consumers;
-				};
-			}
-
-			void flush_production() {
+			bool swap_queues() {
+				bool swapped_queues = false;
 				if (!swap_in_progress) {
-					bool swapped_queues = false;
 					swap_in_progress = true;
 					{
-						std::scoped_lock lock(consumers_mutex, producers_mutex);
-						if (unpublished_resources > 0) {
+						std::lock_guard lock(producers_mutex);
+						if (available_resources == 0 && unpublished_resources > 0) {
 							std::swap(producers_queue, consumers_queue);
 							available_resources = consumers_queue.size();
-							unpublished_resources = producers_queue.size();
+							unpublished_resources = 0;
 							swapped_queues = true;
 						}
 					}
 					swap_in_progress = false;
-					if (swapped_queues) {
-						consumer_notifier.notify_all();
-					}
 				}
+				return swapped_queues;
 			}
+
+		public:
+			template<typename function_type>
+			typename std::enable_if<
+				std::is_same<bool, typename std::result_of<function_type()>::type>::value,
+				void
+			>::type
+			switch_policy(const function_type& custom_policy) {
+				{
+					std::lock_guard lock(consumers_mutex);
+					flush_policy = custom_policy;
+				}
+				consumer_notifier.notify_one();
+			}
+
+			void switch_policy(const flush_policy::batches_of& batches) {
+				{
+					std::lock_guard lock(consumers_mutex);
+					flush_policy = [this, batches] {
+						return unpublished_resources >= batches.batch_size;
+					};
+				}
+				consumer_notifier.notify_one();
+			}
+
+			void switch_policy(const flush_policy::maximum_waiting_consumers& maximum_consumers) {
+				{
+					std::lock_guard lock(consumers_mutex);
+					flush_policy = [this, maximum_consumers] {
+						return waiting_consumers > maximum_consumers.number_of_consumers;
+					};
+				}
+				consumer_notifier.notify_one();
+			}
+
+			production_queue() :
+				available_resources(0),
+				unpublished_resources(0),
+				waiting_consumers(0),
+				swap_in_progress(false)
+			{
+				switch_policy(flush_policy::always);
+			}
+
+			template<typename function_type>
+			production_queue(const function_type& custom_policy) :
+				available_resources(0),
+				unpublished_resources(0),
+				waiting_consumers(0),
+				swap_in_progress(false)
+		   	{
+				switch_policy(custom_policy);
+			}
+
+			production_queue(const flush_policy::batches_of& batches) :
+				available_resources(0),
+				unpublished_resources(0),
+				waiting_consumers(0),
+				swap_in_progress(false)
+			{
+				switch_policy(batches);
+			}
+
+			production_queue(const flush_policy::maximum_waiting_consumers& maximum_consumers) :
+				available_resources(0),
+				unpublished_resources(0),
+				waiting_consumers(0),
+				swap_in_progress(false)
+			{
+				switch_policy(maximum_consumers);
+			}
+
 
 			template<typename... args_types>
 			void produce(args_types... constructor_args) {
@@ -79,25 +126,29 @@ namespace parallel_tools {
 					producers_queue.emplace(std::move(resource));
 					unpublished_resources++;
 				}
-				if (available_resources == 0 && flush_policy()) {
-					flush_production();
-				}
+				consumer_notifier.notify_one();
 			}
 
 			resource_type consume () {
+				bool swapped_queues = false;
 				waiting_consumers++;
 				resource_type resource;
 				{
 					std::unique_lock lock(consumers_mutex);
-					consumer_notifier.wait(lock, [&] { return available_resources > 0; });
+					consumer_notifier.wait(lock, [&] {
+						if (available_resources == 0 && unpublished_resources > 0 && flush_policy()) {
+							swapped_queues = swap_queues();
+						}
+						return available_resources > 0;
+					});
 					waiting_consumers--;
 
 					resource = std::move(consumers_queue.front());
 					consumers_queue.pop();
 					available_resources--;
 				}
-				if (available_resources == 0 && unpublished_resources > 0) {
-					flush_production();
+				if (swapped_queues) {
+					consumer_notifier.notify_all();
 				}
 				return resource;
 			}

--- a/src/objs/production_queue.h
+++ b/src/objs/production_queue.h
@@ -33,6 +33,7 @@ namespace parallel_tools {
 
 			void flush_production() {
 				if (!swap_in_progress) {
+					bool swapped_queues = false;
 					swap_in_progress = true;
 					{
 						std::scoped_lock lock(consumers_mutex, producers_mutex);
@@ -40,10 +41,13 @@ namespace parallel_tools {
 							std::swap(producers_queue, consumers_queue);
 							available_resources = consumers_queue.size();
 							unpublished_resources = producers_queue.size();
+							swapped_queues = true;
 						}
 					}
 					swap_in_progress = false;
-					consumer_notifier.notify_all();
+					if (swapped_queues) {
+						consumer_notifier.notify_all();
+					}
 				}
 			}
 

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -5,9 +5,12 @@
 using namespace std;
 using namespace parallel_tools;
 
-thread_pool::thread_pool(unsigned number_of_threads, size_t maximum_initial_task_delay) :
+thread_pool::thread_pool(unsigned number_of_threads, size_t maximum_task_delay) :
 	running(true),
-	task_queue(maximum_initial_task_delay > 0 ? maximum_initial_task_delay : number_of_threads)
+	task_queue(
+		maximum_task_delay > 0 ? maximum_task_delay : number_of_threads,
+		number_of_threads
+	)
 {
 	threads.reserve(number_of_threads);
 	for (decltype(number_of_threads) i = 0; i < number_of_threads; i++) {

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -1,10 +1,13 @@
 #include "thread_pool.h"
 
+#include <iostream>
+
 using namespace std;
 using namespace parallel_tools;
 
 thread_pool::thread_pool(unsigned number_of_threads) :
-	running(true)
+	running(true),
+	task_queue(number_of_threads)
 {
 	threads.reserve(number_of_threads);
 	for (decltype(number_of_threads) i = 0; i < number_of_threads; i++) {
@@ -25,8 +28,7 @@ thread_pool::~thread_pool() {
 
 void thread_pool::terminate() {
 	running = false;
-	long long tasks_for_wakeup = (long long)threads.size() - (long long)task_queue.available_resources();
-	for (decltype(tasks_for_wakeup) i = 0; i < tasks_for_wakeup; i++) {
+	for (size_t i = 0; i < threads.size(); i++) {
 		exec([]{});
 	}
 

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -1,11 +1,7 @@
 #include "thread_pool.h"
 
-#include <iostream>
-
 using namespace std;
 using namespace parallel_tools;
-
-#include <iostream>
 
 void thread_pool::init_threads(unsigned number_of_threads) {
 	threads.reserve(number_of_threads);

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -5,11 +5,12 @@
 using namespace std;
 using namespace parallel_tools;
 
+#include <iostream>
+
 thread_pool::thread_pool(unsigned number_of_threads, size_t maximum_task_delay) :
 	running(true),
 	task_queue(
-		maximum_task_delay > 0 ? maximum_task_delay : number_of_threads,
-		number_of_threads
+		maximum_task_delay > 0 ? maximum_task_delay : number_of_threads
 	)
 {
 	threads.reserve(number_of_threads);
@@ -34,6 +35,7 @@ void thread_pool::terminate() {
 	for (size_t i = 0; i < threads.size(); i++) {
 		exec([]{});
 	}
+	//task_queue.flush_production();
 
 	for (auto& thread : threads) {
 		thread.join();
@@ -42,5 +44,9 @@ void thread_pool::terminate() {
 
 bool thread_pool::is_running() const {
 	return running;
+}
+
+void thread_pool::finish() {
+	task_queue.flush_production();
 }
 

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -5,9 +5,9 @@
 using namespace std;
 using namespace parallel_tools;
 
-thread_pool::thread_pool(unsigned number_of_threads) :
+thread_pool::thread_pool(unsigned number_of_threads, size_t maximum_initial_task_delay) :
 	running(true),
-	task_queue(number_of_threads)
+	task_queue(maximum_initial_task_delay > 0 ? maximum_initial_task_delay : number_of_threads)
 {
 	threads.reserve(number_of_threads);
 	for (decltype(number_of_threads) i = 0; i < number_of_threads; i++) {

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -49,7 +49,6 @@ void thread_pool::terminate() {
 	for (size_t i = 0; i < threads.size(); i++) {
 		exec([]{});
 	}
-	task_queue.flush_production();
 
 	for (auto& thread : threads) {
 		thread.join();
@@ -58,9 +57,5 @@ void thread_pool::terminate() {
 
 bool thread_pool::is_running() const {
 	return running;
-}
-
-void thread_pool::complete_batch() {
-	task_queue.flush_production();
 }
 

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -7,10 +7,7 @@ using namespace parallel_tools;
 
 #include <iostream>
 
-thread_pool::thread_pool(unsigned number_of_threads, size_t maximum_batch_size) :
-	running(true),
-	task_queue(maximum_batch_size)
-{
+void thread_pool::init_threads(unsigned number_of_threads) {
 	threads.reserve(number_of_threads);
 	for (decltype(number_of_threads) i = 0; i < number_of_threads; i++) {
 		threads.emplace_back([this] {
@@ -20,6 +17,25 @@ thread_pool::thread_pool(unsigned number_of_threads, size_t maximum_batch_size) 
 			}
 		});
 	}
+}
+thread_pool::thread_pool(unsigned number_of_threads) :
+	running(true)
+{
+	init_threads(number_of_threads);
+}
+
+thread_pool::thread_pool(unsigned number_of_threads, const flush_policy::batches_of& batches) :
+	running(true),
+	task_queue(batches)
+{
+	init_threads(number_of_threads);
+}
+
+thread_pool::thread_pool(unsigned number_of_threads, const flush_policy::maximum_waiting_consumers& waiting_threads) :
+	running(true),
+	task_queue(waiting_threads)
+{
+	init_threads(number_of_threads);
 }
 
 thread_pool::~thread_pool() {

--- a/src/objs/thread_pool.cpp
+++ b/src/objs/thread_pool.cpp
@@ -7,11 +7,9 @@ using namespace parallel_tools;
 
 #include <iostream>
 
-thread_pool::thread_pool(unsigned number_of_threads, size_t maximum_task_delay) :
+thread_pool::thread_pool(unsigned number_of_threads, size_t maximum_batch_size) :
 	running(true),
-	task_queue(
-		maximum_task_delay > 0 ? maximum_task_delay : number_of_threads
-	)
+	task_queue(maximum_batch_size)
 {
 	threads.reserve(number_of_threads);
 	for (decltype(number_of_threads) i = 0; i < number_of_threads; i++) {
@@ -35,7 +33,7 @@ void thread_pool::terminate() {
 	for (size_t i = 0; i < threads.size(); i++) {
 		exec([]{});
 	}
-	//task_queue.flush_production();
+	task_queue.flush_production();
 
 	for (auto& thread : threads) {
 		thread.join();
@@ -46,7 +44,7 @@ bool thread_pool::is_running() const {
 	return running;
 }
 
-void thread_pool::finish() {
+void thread_pool::complete_batch() {
 	task_queue.flush_production();
 }
 

--- a/src/objs/thread_pool.h
+++ b/src/objs/thread_pool.h
@@ -17,7 +17,7 @@ namespace parallel_tools {
 			std::vector<std::thread> threads;
 
 		public:
-			thread_pool(unsigned number_of_threads);
+			thread_pool(unsigned number_of_threads, size_t maximum_task_delay = 0);
 			~thread_pool();
 
 			void terminate();

--- a/src/objs/thread_pool.h
+++ b/src/objs/thread_pool.h
@@ -22,8 +22,7 @@ namespace parallel_tools {
 
 			void terminate();
 			bool is_running() const;
-
-			std::future<void> exec(const std::function<void()>& task);
+			void finish();
 
 			template<
 				typename function_type,
@@ -51,6 +50,7 @@ namespace parallel_tools {
 
 				return future;
 			}
+
 	};
 
 }

--- a/src/objs/thread_pool.h
+++ b/src/objs/thread_pool.h
@@ -26,7 +26,6 @@ namespace parallel_tools {
 
 			void terminate();
 			bool is_running() const;
-			void complete_batch();
 
 			template<
 				typename function_type,

--- a/src/objs/thread_pool.h
+++ b/src/objs/thread_pool.h
@@ -17,12 +17,12 @@ namespace parallel_tools {
 			std::vector<std::thread> threads;
 
 		public:
-			thread_pool(unsigned number_of_threads, size_t maximum_task_delay = 0);
+			thread_pool(unsigned number_of_threads, size_t maximum_batch_size = 1);
 			~thread_pool();
 
 			void terminate();
 			bool is_running() const;
-			void finish();
+			void complete_batch();
 
 			template<
 				typename function_type,

--- a/src/objs/thread_pool.h
+++ b/src/objs/thread_pool.h
@@ -9,7 +9,6 @@
 #include "production_queue.h"
 
 namespace parallel_tools {
-
 	class thread_pool {
 		private:
 			volatile bool running;
@@ -53,7 +52,5 @@ namespace parallel_tools {
 
 				return future;
 			}
-
 	};
-
 }

--- a/src/objs/thread_pool.h
+++ b/src/objs/thread_pool.h
@@ -16,8 +16,12 @@ namespace parallel_tools {
 			production_queue<std::packaged_task<void()>> task_queue;
 			std::vector<std::thread> threads;
 
+			void init_threads(unsigned number_of_threads);
+
 		public:
-			thread_pool(unsigned number_of_threads, size_t maximum_batch_size = 1);
+			thread_pool(unsigned number_of_threads);
+			thread_pool(unsigned number_of_threads, const flush_policy::batches_of& batches);
+			thread_pool(unsigned number_of_threads, const flush_policy::maximum_waiting_consumers& waiting_threads);
 			~thread_pool();
 
 			void terminate();

--- a/tests/thread_pool.cpp
+++ b/tests/thread_pool.cpp
@@ -216,6 +216,7 @@ begin_tests {
 			pool.exec(keep_one_thread_busy);
 			pool.exec(keep_one_thread_busy);
 
+			this_thread::sleep_for(5ms);
 			pool.exec([&] {
 				this_thread::sleep_for(15ms);
 				task_dropped = false;
@@ -253,6 +254,7 @@ begin_tests {
 				pool.exec(keep_one_thread_busy);
 				pool.exec(keep_one_thread_busy);
 
+				this_thread::sleep_for(5ms);
 				pool.exec([&] {
 					this_thread::sleep_for(15ms);
 					task_dropped = false;


### PR DESCRIPTION
The communication required for swap of the production and consumer queues was revised to fix the performance problems with a large amount of producers and consumers. Now only the consumers will handle swapping which makes it so that producers can never block consumers and removed the need to atomically acquire two locks during the swap operation.

The flush policy that determined when to swap the queues was also refactored to allow for different policies to be used and for the queue to be able to dynamically switch between different policies. This usage is still to be benchmarked on the thread pool but the expectation is that it will be able to be heavily optimized for specific scenarios by using different policies.